### PR TITLE
Fix dashboard shortcuts and update routing to navigation

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
-import { usePathname, useRouter } from 'expo-router';
+import { usePathname } from 'expo-router';
+import { useNavigation } from '@react-navigation/native';
 import React from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 interface FooterProps {
@@ -8,7 +9,7 @@ interface FooterProps {
 }
 
 const Footer: React.FC<FooterProps> = ({ active, onNavigate }) => {
-  const router = useRouter();
+  const navigation = useNavigation<any>();
   const pathname = usePathname();
 
   const buttons: { key: string; icon: React.ComponentProps<typeof Ionicons>['name']; label: string }[] = [
@@ -28,7 +29,7 @@ const Footer: React.FC<FooterProps> = ({ active, onNavigate }) => {
             if (onNavigate) {
               onNavigate(btn.key);
             } else {
-              router.push(btn.key as any);
+              navigation.navigate(btn.key as never);
             }
           }}
         >

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -7,13 +7,14 @@ import { UserLogin } from "@/src/types/userTypes";
 import { delay } from "@/src/utils/delay";
 import { useFormState } from "@/src/utils/useStatePersolaize";
 import { Ionicons } from '@expo/vector-icons';
-import { router } from "expo-router";
+import { useNavigation } from "@react-navigation/native";
 import { useState } from "react";
 import { Image, SafeAreaView, Text, TextInput, TouchableOpacity, View } from "react-native";
 import styles from "./styles";
 
 export default function Login() {
   const { login } = useAuth();
+  const navigation = useNavigation<any>();
 
   const { state: form, updateField } = useFormState<UserLogin>({
     userName: "",
@@ -48,7 +49,7 @@ export default function Login() {
         login({ token: response.token });
 
         await delay(2000);
-        router.push("/principal/page");
+        navigation.navigate('/principal/page');
       }
     } catch (err) {
       updateErrorField("returnError", true);

--- a/src/app/(costumers)/_layout.tsx
+++ b/src/app/(costumers)/_layout.tsx
@@ -2,14 +2,16 @@ import Footer from '@/components/Footer';
 import { Stack } from 'expo-router';
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
 export default function CostumersGroupLayout() {
+  const navigation = useNavigation<any>();
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
       <View style={{ flex: 1, paddingBottom: 70 }}>
         <Stack screenOptions={{ headerShown: false }} />
       </View>
-      <Footer />
+      <Footer onNavigate={(screen) => navigation.navigate(screen as never)} />
     </SafeAreaView>
   );
 }

--- a/src/app/(costumers)/list/page.tsx
+++ b/src/app/(costumers)/list/page.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useState } from "react";
+import { useRoute } from "@react-navigation/native";
+import { useEffect, useState } from "react";
 import {
     FlatList,
     Modal,
@@ -13,6 +14,7 @@ import {
 import styles from "./styles";
 
 export default function CustomerList() {
+  const route = useRoute<any>();
   const [filters, setFilters] = useState({
     number: "",
     plate: "",
@@ -27,6 +29,13 @@ export default function CustomerList() {
     { id: 2, name: "Maria Souza", plate: "XYZ-9876", phone: "98888-2222", status: "Pendente" },
     { id: 3, name: "Erik Sena", plate: "DEF-4567", phone: "97777-3333", status: "Pago" },
   ]);
+
+  const initialStatusFilter = (route.params as any)?.status as string | undefined;
+  useEffect(() => {
+    if (initialStatusFilter) {
+      setFilters(prev => ({ ...prev, status: initialStatusFilter }));
+    }
+  }, [initialStatusFilter]);
 
   const renderItem = ({ item }: any) => (
     <View style={styles.customerCard}>

--- a/src/app/(panel)/_layout.tsx
+++ b/src/app/(panel)/_layout.tsx
@@ -2,14 +2,16 @@ import Footer from '@/components/Footer';
 import { Stack } from 'expo-router';
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 
 export default function PanelGroupLayout() {
+  const navigation = useNavigation<any>();
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
       <View style={{ flex: 1, paddingBottom: 70 }}>
         <Stack screenOptions={{ headerShown: false }} />
       </View>
-      <Footer />
+      <Footer onNavigate={(screen) => navigation.navigate(screen as never)} />
     </SafeAreaView>
   );
 }

--- a/src/app/(panel)/pagamentos/registrar/page.tsx
+++ b/src/app/(panel)/pagamentos/registrar/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SafeAreaView, Text, View } from 'react-native';
+
+export default function RegistrarPagamentoPage() {
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text style={{ fontSize: 18 }}>Registrar Pagamento</Text>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/app/(panel)/principal/page.tsx
+++ b/src/app/(panel)/principal/page.tsx
@@ -3,7 +3,7 @@ import { getDashboard } from '@/src/services/dashboardService';
 import { DashboardProps } from '@/src/types/userTypes';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { router } from 'expo-router';
+import { useNavigation } from '@react-navigation/native';
 import React, { useEffect, useState } from "react";
 import { SafeAreaView, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import styles from './styles';
@@ -20,18 +20,20 @@ type QuickAction = {
   title: string;
   icon: MaterialIconName;
   color: string;
-  screen: string;
+  routeName: string;
+  params?: Record<string, any>;
 };
 
 const quickActions: QuickAction[] = [
-  { id: '1', title: 'Clientes Adimplentes', icon: 'person', color: '#3B82F6', screen: "/list/page" },
-  { id: '2', title: 'Clientes Inadimplentes', icon: 'warning', color: '#3B82F6', screen: 'Inadimplentes' },
-  { id: '3', title: 'Vagas Disponíveis', icon: 'local-parking', color: '#3B82F6', screen: 'Vagas' },
-  { id: '4', title: 'Registrar Pagamento', icon: 'credit-card', color: '#3B82F6', screen: 'RegistrarPagamento' },
+  { id: '1', title: 'Clientes Adimplentes', icon: 'person', color: '#3B82F6', routeName: '/list/page', params: { status: 'Pago' } },
+  { id: '2', title: 'Clientes Inadimplentes', icon: 'warning', color: '#3B82F6', routeName: '/list/page', params: { status: 'Pendente' } },
+  { id: '3', title: 'Vagas Disponíveis', icon: 'local-parking', color: '#3B82F6', routeName: '/vagas/page' },
+  { id: '4', title: 'Registrar Pagamento', icon: 'credit-card', color: '#3B82F6', routeName: '/pagamentos/registrar/page' },
 ];
 
 export default function DashboardPage() {
   const [data, setData] = useState<DashboardProps | null>(null);
+  const navigation = useNavigation<any>();
   useEffect(() => {
     async function fetchDashboard() {
       try {
@@ -66,7 +68,7 @@ export default function DashboardPage() {
             <TouchableOpacity
               key={action.id}
               style={styles.quickCard}
-              onPress={() => router.push("/list/page")}
+              onPress={() => navigation.navigate(action.routeName as never, action.params as never)}
             >
               <MaterialIcons name={action.icon} size={32} color={action.color} />
               <Text style={styles.quickCardText}>{action.title}</Text>

--- a/src/app/(panel)/vagas/page.tsx
+++ b/src/app/(panel)/vagas/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SafeAreaView, Text, View } from 'react-native';
+
+export default function VagasPage() {
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text style={{ fontSize: 18 }}>Vagas Disponíveis</Text>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,5 @@
-import { router, Stack } from "expo-router";
+import { Stack } from "expo-router";
+import { useNavigation } from "@react-navigation/native";
 import { useEffect } from "react";
 import { AuthProvider, useAuth } from "../context/AuthContext";
 
@@ -12,14 +13,15 @@ export default function RootLayout() {
 
 function MainLayout() {
   const { dataReturn} = useAuth();
+  const navigation = useNavigation<any>();
 
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (dataReturn?.token) {
-        router.replace("/principal/page");
+        navigation.reset({ index: 0, routes: [{ name: '/principal/page' as never }] as any });
         return;
       } else {
-        router.replace("/(auth)/page");
+        navigation.reset({ index: 0, routes: [{ name: '/(auth)/page' as never }] as any });
         return;
       }
     }, 500);

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,14 +1,14 @@
 import Colors from "@/constants/Colors";
-import { useRouter } from "expo-router";
+import { useNavigation } from "@react-navigation/native";
 import { useEffect } from "react";
 import { Image, SafeAreaView, StyleSheet, Text, View } from "react-native";
 
 export default function Home() {
-  const router = useRouter();
+  const navigation = useNavigation<any>();
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      router.replace("/(auth)/page");
+      navigation.reset({ index: 0, routes: [{ name: '/(auth)/page' as never }] as any });
     }, 3000);
 
     return () => clearTimeout(timer);


### PR DESCRIPTION
Fix dashboard shortcuts to navigate to correct pages and replace `expo-router`'s `router` with `@react-navigation/native`'s `navigation` throughout the system.

Previously, all dashboard shortcuts led to the same customer list page. This PR ensures each shortcut directs to its intended, distinct screen, and refactors the navigation API as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ad8d89d-f299-4451-a934-dabbfa6edd1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ad8d89d-f299-4451-a934-dabbfa6edd1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

