### PR TITLE
Fix footer navigation errors with router

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -5,16 +5,15 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 interface FooterProps {
   active?: string;
-  onNavigate?: (screen: string) => void;
 }
 
-const Footer: React.FC<FooterProps> = ({ active, onNavigate }) => {
+const Footer: React.FC<FooterProps> = ({ active }) => {
   const pathname = usePathname();
 
   // Defina os caminhos exatos das suas rotas no Expo Router
-  const buttons: { key: "/principal" | "/list"; icon: React.ComponentProps<typeof Ionicons>['name']; label: string }[] = [
-    { key: '/principal', icon: 'home-outline', label: 'Home' },
-    { key: '/list', icon: 'people-outline', label: 'Clientes' },
+  const buttons: { key: "/principal/page" | "/list/page"; icon: React.ComponentProps<typeof Ionicons>['name']; label: string }[] = [
+    { key: '/principal/page', icon: 'home-outline', label: 'Home' },
+    { key: '/list/page', icon: 'people-outline', label: 'Clientes' },
   ];
 
   const activeKey = active ?? buttons.find((btn) => pathname.startsWith(btn.key))?.key;
@@ -26,11 +25,7 @@ const Footer: React.FC<FooterProps> = ({ active, onNavigate }) => {
           key={btn.key}
           style={styles.footerButton}
           onPress={() => {
-            if (onNavigate) {
-              onNavigate(btn.key);
-            } else {
-              router.push(btn.key as any);
-            }
+            router.push(btn.key as any);
           }}
         >
           <Ionicons

--- a/src/app/(auth)/page.tsx
+++ b/src/app/(auth)/page.tsx
@@ -7,14 +7,13 @@ import { UserLogin } from "@/src/types/userTypes";
 import { delay } from "@/src/utils/delay";
 import { useFormState } from "@/src/utils/useStatePersolaize";
 import { Ionicons } from '@expo/vector-icons';
-import { useNavigation } from "@react-navigation/native";
+import { router } from "expo-router";
 import { useState } from "react";
 import { Image, SafeAreaView, Text, TextInput, TouchableOpacity, View } from "react-native";
 import styles from "./styles";
 
 export default function Login() {
   const { login } = useAuth();
-  const navigation = useNavigation<any>();
 
   const { state: form, updateField } = useFormState<UserLogin>({
     userName: "",
@@ -49,7 +48,7 @@ export default function Login() {
         login({ token: response.token });
 
         await delay(2000);
-        navigation.navigate('/principal/page');
+        router.replace('/principal/page');
       }
     } catch (err) {
       updateErrorField("returnError", true);

--- a/src/app/(costumers)/_layout.tsx
+++ b/src/app/(costumers)/_layout.tsx
@@ -2,16 +2,14 @@ import Footer from '@/components/Footer';
 import { Stack } from 'expo-router';
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 
 export default function CostumersGroupLayout() {
-  const navigation = useNavigation<any>();
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
       <View style={{ flex: 1, paddingBottom: 70 }}>
         <Stack screenOptions={{ headerShown: false }} />
       </View>
-      <Footer onNavigate={(screen) => navigation.navigate(screen as never)} />
+      <Footer />
     </SafeAreaView>
   );
 }

--- a/src/app/(panel)/_layout.tsx
+++ b/src/app/(panel)/_layout.tsx
@@ -2,16 +2,14 @@ import Footer from '@/components/Footer';
 import { Stack } from 'expo-router';
 import React from 'react';
 import { SafeAreaView, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 
 export default function PanelGroupLayout() {
-  const navigation = useNavigation<any>();
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: '#FFFFFF' }}>
       <View style={{ flex: 1, paddingBottom: 70 }}>
         <Stack screenOptions={{ headerShown: false }} />
       </View>
-      <Footer onNavigate={(screen) => navigation.navigate(screen as never)} />
+      <Footer />
     </SafeAreaView>
   );
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,17 +1,12 @@
 import Colors from "@/constants/Colors";
-import { useNavigation } from "@react-navigation/native";
+import { router } from "expo-router";
 import { useEffect } from "react";
 import { Image, SafeAreaView, StyleSheet, Text, View } from "react-native";
 
 export default function Home() {
-  const navigation = useNavigation<any>();
-
   useEffect(() => {
     const timer = setTimeout(() => {
-      navigation.reset({
-        index: 0,
-        routes: [{ name: "Login" }],
-      });
+      router.replace('/(auth)/page');
     }, 3000);
 
     return () => clearTimeout(timer);


### PR DESCRIPTION
Refactor navigation to consistently use `expo-router` and correct route paths, resolving 'NAVIGATE' errors.

The previous implementation mixed `react-navigation` with `expo-router` for navigation, leading to errors where `expo-router` could not find routes like `/principal` or `/list`. This PR standardizes all navigation calls to `router.push` or `router.replace` with the correct file-based `expo-router` paths (e.g., `/principal/page`).

---
<a href="https://cursor.com/background-agent?bcId=bc-beadeacb-d172-477c-b5b8-5656f4e4eb18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-beadeacb-d172-477c-b5b8-5656f4e4eb18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

